### PR TITLE
Added command line proxy argument, to set chrome proxy settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 - [Introduction](#introduction)
 - [Downloads](#downloads)
+- [Settings](#settings)
 - [Report Bugs](#report-bugs)
 - [Development](#development)
 - [Deployment](#deployment)
@@ -27,6 +28,11 @@ Tweet Tray is a small application which allows you to tweet from your desktop ta
 #### 🐧 [Linux (DEB File)](https://github.com/jonathontoon/tweet-tray/releases/download/v1.1.2/tweet-tray-1.1.2.deb)
 
 See [releases](https://github.com/jonathontoon/tweet-tray/releases) for more information.
+
+## Settings
+Some application settings can be passed via commandline arguments. For a full list, run the executable from the commandline with the  `--help` argument. 
+- `--proxy` You can configure Tweet Tray to use a HTTP [proxy server](https://en.wikipedia.org/wiki/Proxy_server), by setting the `--proxy` argument.  This takes a string value of the proxy server address and port, in the form of `--proxy address:port`.  This also supports [SOCKS5](https://en.wikipedia.org/wiki/SOCKS) by using the `socks5` protocol prefix, eg `--proxy socks5://address:port`. 
+
 
 ## Report Bugs
 Please create a Github [issue](https://github.com/jonathontoon/tweet-tray/issues) and provide as much information as possible regarding the bug, including images or error codes. To make things as uniform as possible please follow the guidelines set out in `ISSUE_TEMPLATE.md`.

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -6,11 +6,36 @@
 
 import url from 'url';
 import path from 'path';
+import yargs from 'yargs';
 import { app, ipcMain, globalShortcut, } from 'electron';
 
 import config from './Config';
 import MenuBarManager from './MenuBarManager';
 import OAuthManager from './OAuthManager';
+
+/*
+  Commandline settings
+ */
+const conf = yargs
+  .option('p', {
+    alias: 'proxy',
+    describe: 'Proxy server (address:port, socks5://address:port)',
+    type: 'string',
+  })
+  .parse(process.argv.slice(1));
+
+
+/*
+  Configure Proxy settings
+ */
+if (conf.proxy) {
+  const proxyURL = url.parse(conf.proxy);
+
+  app.commandLine.appendSwitch('proxy-server', proxyURL.href);
+  if (proxyURL.protocol === 'socks5:') {
+    app.commandLine.appendSwitch('host-resolver-rules', `MAP * ~NOTFOUND , EXCLUDE ${proxyURL.hostname}`);
+  }
+}
 
 /*
   Variables

--- a/app/package.json
+++ b/app/package.json
@@ -14,5 +14,7 @@
     "postinstall": "npm run electron-rebuild"
   },
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "yargs": "^11.0.0"
+  }
 }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- By making a contribution, you agree to our Code Of Conduct.
-->

<!-- Provide a general summary of the changes in the title above -->
Added a command line argument (`--proxy`), so that you can set Chrome's proxy setting.  I've used yargs, so you also get a nice little help message if you try `--help`.

Might be nice to localise this at some point.

Only tested on Linux, using [Charles Proxy](https://www.charlesproxy.com/).

## Preflight Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
https://github.com/jonathontoon/tweet-tray/issues/57

## Semver Changes
<!-- Which semantic version change would you recommend? -->
minor